### PR TITLE
fix: allow conditional function calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = {
 
     // Base
 
-    "no-unused-expressions": ["error", { allowTernary: true }],
+    "no-unused-expressions": "off",
     "no-console": "error",
     "no-confusing-arrow": "off",
     "no-else-return": "off",
@@ -64,6 +64,7 @@ module.exports = {
         ignoreRestSiblings: true,
       },
     ],
+    "@typescript-eslint/no-unused-expressions": ["error", { allowShortCircuit: true, allowTernary: true }],
 
     // React
 


### PR DESCRIPTION
## Problem

With the current configuration, using the optional-chaining operator to call a function is a violation:
```
visNetwork.current?.fit();
```
>  **_error_**  Expected an assignment or function call and instead saw an expression  _no-unused-expres
sions_

I ran into this while converting `elements` to `eslint`.

## Proposal

`typescript-eslint` has [a rule](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-expressions.md) that extends the original `no-unused-expressions` with TypeScript specific features, such as support for optional chaining.

**_+1_** I enabled `allowShortCircuit` because `allowTernary` was enabled, and the latter looks weird without the former IMO. (As every short circuit can be written as a ternary.)