### PR TITLE
feat: disable `arrow-parens`

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ module.exports = {
     "no-restricted-syntax": "off",
     "no-param-reassign": ["error", { props: false }],
     "arrow-body-style": "off",
+    "arrow-parens": "off",
 
     // Imports
 

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  arrowParens: "avoid",
   printWidth: 120,
   trailingComma: "all",
   proseWrap: "always",


### PR DESCRIPTION
This allows arrow functions without parenthesis around the arguments.
https://eslint.org/docs/rules/arrow-parens

Parentheses are still allowed by `eslint` but not required anymore. `prettier` will try to avoid them - if installed and using the default config.